### PR TITLE
Add prettier auto-formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1188,6 +1188,12 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.6.tgz",
       "integrity": "sha512-d0BOAicT0tEdbdVQlLGOVul1kvg6YvbaADRCThGCz5NJ0e9r00SofcR1x69hmlCyrHuB6jd4cKzL9bMLjPnpAA=="
     },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
     "@types/prop-types": {
       "version": "15.7.1",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
@@ -1717,6 +1723,12 @@
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
+    "array-differ": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-2.1.0.tgz",
+      "integrity": "sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w==",
+      "dev": true
+    },
     "array-filter": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
@@ -1782,8 +1794,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "optional": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asap": {
       "version": "2.0.6",
@@ -1824,7 +1835,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "requires": {
             "inherits": "2.0.1"
@@ -1854,7 +1865,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "async-each": {
@@ -2447,7 +2458,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -2481,7 +2492,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -3420,7 +3431,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -3432,7 +3443,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -4065,7 +4076,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -5411,7 +5422,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5429,11 +5441,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5446,15 +5460,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5557,7 +5574,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5567,6 +5585,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5579,17 +5598,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5606,6 +5628,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5678,7 +5701,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5688,6 +5712,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5763,7 +5788,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5793,6 +5819,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5810,6 +5837,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5848,11 +5876,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -6602,7 +6632,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
@@ -7382,6 +7412,163 @@
         }
       }
     },
+    "husky": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-3.0.0.tgz",
+      "integrity": "sha512-lKMEn7bRK+7f5eWPNGclDVciYNQt0GIkAQmhKl+uHP1qFzoN0h92kmH9HZ8PCwyVA2EQPD8KHf0FYWqnTxau+Q==",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^5.2.1",
+        "execa": "^1.0.0",
+        "get-stdin": "^7.0.0",
+        "is-ci": "^2.0.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^4.2.0",
+        "please-upgrade-node": "^3.1.1",
+        "read-pkg": "^5.1.1",
+        "run-node": "^1.0.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "get-stdin": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+          "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -7555,12 +7742,14 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "optional": true
         },
         "slice-ansi": {
           "version": "1.0.0",
@@ -7586,6 +7775,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -7664,7 +7854,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "requires": {
         "from2": "^2.1.1",
@@ -8345,6 +8535,12 @@
         "type-check": "~0.3.2"
       }
     },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -8549,7 +8745,8 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -8572,6 +8769,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -9040,7 +9238,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mississippi": {
@@ -9102,7 +9300,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -9110,7 +9308,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -9133,6 +9331,12 @@
         "run-queue": "^1.0.3"
       }
     },
+    "mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -9151,6 +9355,18 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "multimatch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-3.0.0.tgz",
+      "integrity": "sha512-22foS/gqQfANZ3o+W7ST2x25ueHDVNWl/b9OlGcLpy/iKxjCpvcNCM51YCenUi7Mt/jAjjqv8JwZRs8YP5sRjA==",
+      "dev": true,
+      "requires": {
+        "array-differ": "^2.0.3",
+        "array-union": "^1.0.2",
+        "arrify": "^1.0.1",
+        "minimatch": "^3.0.4"
+      }
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -9663,6 +9879,12 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "opencollective-postinstall": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
+      "dev": true
+    },
     "opentracing": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.3.tgz",
@@ -10047,7 +10269,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
@@ -10109,6 +10331,15 @@
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
         }
+      }
+    },
+    "please-upgrade-node": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz",
+      "integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
       }
     },
     "pnp-webpack-plugin": {
@@ -10868,6 +11099,43 @@
         "utila": "~0.4"
       }
     },
+    "pretty-quick": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-1.11.1.tgz",
+      "integrity": "sha512-kSXCkcETfak7EQXz6WOkCeCqpbC4GIzrN/vaneTGMP/fAtD8NerA9bPhCUqHAks1geo7biZNl5uEMPceeneLuA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0",
+        "execa": "^0.8.0",
+        "find-up": "^2.1.0",
+        "ignore": "^3.3.7",
+        "mri": "^1.1.0",
+        "multimatch": "^3.0.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        }
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -11017,7 +11285,7 @@
     },
     "query-string": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
@@ -11401,7 +11669,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -11554,7 +11822,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
@@ -11871,6 +12139,12 @@
         "is-promise": "^2.1.0"
       }
     },
+    "run-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
+      "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
+      "dev": true
+    },
     "run-queue": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -11907,7 +12181,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -12186,6 +12460,12 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
     "semver-diff": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
@@ -12345,7 +12625,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -13092,7 +13372,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -13110,7 +13390,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-indent": {
@@ -13367,7 +13647,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -14706,7 +14986,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "gatsby build",
     "deploy": "npm run build && gh-pages -d public",
-    "format": "prettier --write src/**/*.{js,jsx}",
+    "format": "prettier --write src/**/*.{js,jsx,ts,tsx}",
     "start": "gatsby develop",
     "serve": "gatsby serve",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
@@ -36,6 +36,14 @@
     "@types/react-helmet": "^5.0.8",
     "gatsby-plugin-typescript": "^2.0.13",
     "gh-pages": "^2.0.1",
-    "prettier": "^1.17.0"
-  }
+    "husky": "^3.0.0",
+    "prettier": "^1.17.0",
+    "pretty-quick": "^1.11.1"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
+  },
+  "prettier": {}
 }

--- a/src/components/EditLink.tsx
+++ b/src/components/EditLink.tsx
@@ -1,5 +1,5 @@
-import { css, SerializedStyles } from '@emotion/core';
-import React from 'react';
+import { css, SerializedStyles } from "@emotion/core";
+import React from "react";
 
 const edit: SerializedStyles = css`
   display: flex;
@@ -42,7 +42,7 @@ const EditLink = ({ relativePath }: Props) => {
   return (
     <div css={edit}>
       <a css={link} href={href} target="_blank">
-        <span>Edit this page on GitHub</span>{' '}
+        <span>Edit this page on GitHub</span>{" "}
         <svg
           css={icon}
           fill="currentColor"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,10 +1,10 @@
-import React, { FunctionComponent } from "react"
+import React, { FunctionComponent } from "react";
 
-import { Link } from "gatsby"
-import SocialBar from "./SocialBar"
-import gitHubIcon from "./Footer/GitHub.png"
-import jenkinsIcon from "./Footer/jenkins_headshot.png"
-import slackIcon from "./Footer/slack.svg"
+import { Link } from "gatsby";
+import SocialBar from "./SocialBar";
+import gitHubIcon from "./Footer/GitHub.png";
+import jenkinsIcon from "./Footer/jenkins_headshot.png";
+import slackIcon from "./Footer/slack.svg";
 
 export interface FooterProps {}
 
@@ -72,7 +72,7 @@ export const Footer: FunctionComponent<FooterProps> = () => {
         </a>
       </p>
     </footer>
-  )
-}
+  );
+};
 
-export default Footer
+export default Footer;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,10 @@
-import React, { FunctionComponent, useState } from "react"
+import React, { FunctionComponent, useState } from "react";
 
-import { IconButton } from "office-ui-fabric-react"
-import { Link } from "gatsby"
-import Menu from "./Header/Menu"
-import SocialBar from "./SocialBar"
-import logo from "./adopt_logo_white.svg"
+import { IconButton } from "office-ui-fabric-react";
+import { Link } from "gatsby";
+import Menu from "./Header/Menu";
+import SocialBar from "./SocialBar";
+import logo from "./adopt_logo_white.svg";
 
 export interface HeaderProps {}
 
@@ -14,12 +14,12 @@ interface BannersProps {}
  * This is where you can add banners to the website (nothing here now)
  */
 const Banners: React.FunctionComponent<BannersProps> = () => {
-  return <div />
-}
+  return <div />;
+};
 
 export const Header: FunctionComponent<HeaderProps> = () => {
-  const [isMenuOpen, setIsMenuOpen] = useState(false)
-  const handleClick = () => setIsMenuOpen(prevState => !prevState)
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const handleClick = () => setIsMenuOpen(prevState => !prevState);
 
   return (
     <>
@@ -28,7 +28,7 @@ export const Header: FunctionComponent<HeaderProps> = () => {
         <IconButton
           styles={{
             icon: { color: "white", fontSize: "2.25em" },
-            root: { position: "absolute", left: "2rem", top: 0 },
+            root: { position: "absolute", left: "2rem", top: 0 }
           }}
           iconProps={{ iconName: "bars" }}
           title="Menu"
@@ -44,7 +44,7 @@ export const Header: FunctionComponent<HeaderProps> = () => {
       </nav>
       <Banners />
     </>
-  )
-}
+  );
+};
 
-export default Header
+export default Header;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,30 +1,30 @@
-import "./index.css"
-import "../scss/styles-0-master.scss"
-import "../scss/styles-1-large-main.scss"
+import "./index.css";
+import "../scss/styles-0-master.scss";
+import "../scss/styles-1-large-main.scss";
 
-import React, { FunctionComponent } from "react"
+import React, { FunctionComponent } from "react";
 
-import Footer from "./Footer"
-import Header from "./Header"
-import Helmet from "react-helmet"
-import { registerIcons } from "office-ui-fabric-react"
+import Footer from "./Footer";
+import Header from "./Header";
+import Helmet from "react-helmet";
+import { registerIcons } from "office-ui-fabric-react";
 
 registerIcons({
   icons: {
     "arrow-circle-left": <i className="fa fa-arrow-circle-left" />,
     bars: <i className="fa fa-bars" />,
     cancel: <i className="fa fa-times" />,
-    chevrondown: <i className="fa fa-chevron-down" />,
-  },
-})
+    chevrondown: <i className="fa fa-chevron-down" />
+  }
+});
 
 export interface LayoutProps {
-  className?: string
+  className?: string;
 }
 
 export const Layout: FunctionComponent<LayoutProps> = ({
   children,
-  className = "",
+  className = ""
 }) => {
   return (
     <>
@@ -62,7 +62,7 @@ export const Layout: FunctionComponent<LayoutProps> = ({
       <main className={`grey-bg ${className}`}>{children}</main>
       <Footer />
     </>
-  )
-}
+  );
+};
 
-export default Layout
+export default Layout;

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,9 +1,16 @@
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent } from "react";
 
 const Loading: FunctionComponent = () => {
-    return(
-        <div id="loading"><img src="dist/assets/loading_dots.gif" width="40" height="40" alt="Content is loading."/></div>
-    )
-}
+  return (
+    <div id="loading">
+      <img
+        src="dist/assets/loading_dots.gif"
+        width="40"
+        height="40"
+        alt="Content is loading."
+      />
+    </div>
+  );
+};
 
-export default Loading
+export default Loading;

--- a/src/components/NavButton.tsx
+++ b/src/components/NavButton.tsx
@@ -1,22 +1,26 @@
-import React, {FunctionComponent, ReactChild} from 'react'
+import React, { FunctionComponent, ReactChild } from "react";
 
 export interface NavButtonProps {
-    href: string,
-    type: string,
-    children: ReactChild
+  href: string;
+  type: string;
+  children: ReactChild;
 }
 
-const NavButton: FunctionComponent<NavButtonProps> = ({href, type, children}) => {
+const NavButton: FunctionComponent<NavButtonProps> = ({
+  href,
+  type,
+  children
+}) => {
+  const color = type === "primary" ? "blue" : "grey";
 
-    const color = type === "primary" ? "blue" : "grey"
+  return (
+    <a href={href} className={`${color}-button a-button`}>
+      <div>
+        <span>{children}</span>{" "}
+        <i className="fa fa-arrow-circle-o-right" aria-hidden="true" />
+      </div>
+    </a>
+  );
+};
 
-    return (
-        <a href={href} className={`${color}-button a-button`}>
-            <div>
-                <span>{children}</span> <i className="fa fa-arrow-circle-o-right" aria-hidden="true"/>
-            </div>
-        </a>
-    )
-}
-
-export default NavButton
+export default NavButton;

--- a/src/components/ReleaseSelector.tsx
+++ b/src/components/ReleaseSelector.tsx
@@ -1,15 +1,15 @@
-import React, { FunctionComponent, SyntheticEvent } from "react"
+import React, { FunctionComponent, SyntheticEvent } from "react";
 
-import { ChoiceGroup } from "office-ui-fabric-react"
+import { ChoiceGroup } from "office-ui-fabric-react";
 
 export interface ReleaseSelectorProps {
-  onVersionChange(e: SyntheticEvent): void
-  onJVMChange(e: SyntheticEvent): void
+  onVersionChange(e: SyntheticEvent): void;
+  onJVMChange(e: SyntheticEvent): void;
 }
 
 const ReleaseSelector: FunctionComponent<ReleaseSelectorProps> = ({
   onVersionChange,
-  onJVMChange,
+  onJVMChange
 }) => {
   return (
     <div className="btn-container">
@@ -21,16 +21,16 @@ const ReleaseSelector: FunctionComponent<ReleaseSelectorProps> = ({
           options={[
             {
               key: "A",
-              text: "OpenJDK 8 (LDS)",
+              text: "OpenJDK 8 (LDS)"
             },
             {
               key: "B",
-              text: "OpenJDK 9",
+              text: "OpenJDK 9"
             },
             {
               key: "C",
-              text: "OpenJDK 10",
-            },
+              text: "OpenJDK 10"
+            }
           ]}
         />
       </form>
@@ -86,17 +86,17 @@ const ReleaseSelector: FunctionComponent<ReleaseSelectorProps> = ({
           options={[
             {
               key: "A",
-              text: "HotSpot",
+              text: "HotSpot"
             },
             {
               key: "B",
-              text: "OpenJ9",
-            },
+              text: "OpenJ9"
+            }
           ]}
         />
       </form>
     </div>
-  )
-}
+  );
+};
 
-export default ReleaseSelector
+export default ReleaseSelector;

--- a/src/components/SocialBar.tsx
+++ b/src/components/SocialBar.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from "react"
+import React, { FunctionComponent } from "react";
 
 export interface SocialBarProps {}
 
@@ -50,7 +50,7 @@ export const SocialBar: FunctionComponent<SocialBarProps> = () => {
         </a>
       </div>
     </>
-  )
-}
+  );
+};
 
-export default SocialBar
+export default SocialBar;

--- a/src/pages/archive.tsx
+++ b/src/pages/archive.tsx
@@ -1,60 +1,70 @@
-import React, {FunctionComponent, SyntheticEvent} from 'react'
-import Layout from '../components/Layout'
+import React, { FunctionComponent, SyntheticEvent } from "react";
+import Layout from "../components/Layout";
 
-export interface ArchiveProps {
-}
+export interface ArchiveProps {}
 
-import "../scss/styles-12-archive.scss"
+import "../scss/styles-12-archive.scss";
 import ArchiveReleaseRow from "../components/Archive/ArchiveReleaseRow";
 import ReleaseSelector from "../components/ReleaseSelector";
 import Loading from "../components/Loading";
 import NavButton from "../components/NavButton";
 
 const Archive: FunctionComponent<ArchiveProps> = props => {
+  const loading = false;
+  const error = false;
+  const releases = [];
 
-    const loading = false
-    const error = false
-    const releases = []
+  if (loading) {
+    return <Loading />;
+  }
 
-    if(loading) {
-        return <Loading />
-    }
+  if (error) {
+    return <div id="error-container" />;
+  }
 
-    if(error) {
-        return <div id="error-container" />
-    }
+  return (
+    <Layout>
+      <main className="grey-bg">
+        <div id="archives-page">
+          <h1 className="large-title">Archive</h1>
 
-    return (
-        <Layout>
-            <main className="grey-bg">
+          <div className="callout">
+            <p>
+              Please be aware that using old, superseded, or otherwise
+              unsupported releases is not recommended.
+            </p>
+          </div>
 
-                <div id="archives-page">
-                    <h1 className="large-title">Archive</h1>
+          <NavButton href="releases" type="primary">
+            Latest Releases
+          </NavButton>
+          <NavButton href="nightly" type="secondary">
+            Nightly Builds
+          </NavButton>
 
-                    <div className="callout">
-                        <p>Please be aware that using old, superseded, or otherwise unsupported releases is not recommended.</p>
-                    </div>
+          <ReleaseSelector
+            onVersionChange={(e: SyntheticEvent) => {
+              console.log(e);
+            }}
+            onJVMChange={(e: SyntheticEvent) => {
+              console.log(e);
+            }}
+          />
 
-                    <NavButton href="releases" type="primary">Latest Releases</NavButton>
-                    <NavButton href="nightly" type="secondary">Nightly Builds</NavButton>
+          <div id="archive-list" className="hide">
+            <div id="pagination-container" />
+            <table className="archive-container">
+              <tbody id="archive-table-body">
+                {releases.map(release => (
+                  <ArchiveReleaseRow release={release} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </main>
+    </Layout>
+  );
+};
 
-                    <ReleaseSelector
-                        onVersionChange={(e: SyntheticEvent)=> {console.log(e)}}
-                        onJVMChange={(e: SyntheticEvent)=> {console.log(e)}}
-                    />
-
-                    <div id="archive-list" className="hide">
-                        <div id="pagination-container"></div>
-                        <table className='archive-container'>
-                            <tbody id='archive-table-body'>
-                                { releases.map(release => <ArchiveReleaseRow release={release} />)}
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </main>
-        </Layout>
-    );
-}
-
-export default Archive
+export default Archive;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,10 @@
-import "../scss/styles-2-index.scss"
+import "../scss/styles-2-index.scss";
 
-import Layout from "../components/Layout"
-import { Link } from "gatsby"
-import React from "react"
-import ReleaseSelector from "../components/ReleaseSelector"
-import loadingDots from "../assets/loading_dots.gif"
+import Layout from "../components/Layout";
+import { Link } from "gatsby";
+import React from "react";
+import ReleaseSelector from "../components/ReleaseSelector";
+import loadingDots from "../assets/loading_dots.gif";
 
 const App: React.FunctionComponent = () => {
   return (
@@ -215,7 +215,7 @@ const App: React.FunctionComponent = () => {
         </div>
       </main>
     </Layout>
-  )
-}
+  );
+};
 
-export default App
+export default App;

--- a/src/pages/nightly.tsx
+++ b/src/pages/nightly.tsx
@@ -1,111 +1,128 @@
-import React, {FunctionComponent, SyntheticEvent} from "react"
-import Layout from "../components/Layout"
+import React, { FunctionComponent, SyntheticEvent } from "react";
+import Layout from "../components/Layout";
 import Loading from "../components/Loading";
-import NavButton from "../components/NavButton"
-import { PrimaryButton } from 'office-ui-fabric-react'
+import NavButton from "../components/NavButton";
+import { PrimaryButton } from "office-ui-fabric-react";
 import ReleaseSelector from "../components/ReleaseSelector";
 
-import "../scss/styles-3-nightly.scss"
+import "../scss/styles-3-nightly.scss";
 
-export interface NightlyProps {
-}
+export interface NightlyProps {}
 
 const Nightly: FunctionComponent<NightlyProps> = props => {
-
-    const loading = false
-    const thisInstallerLink = false
-    const platforms = [{
-        placeholder: true
-    }]
-
-    if (loading) {
-        return <Loading/>
+  const loading = false;
+  const thisInstallerLink = false;
+  const platforms = [
+    {
+      placeholder: true
     }
+  ];
 
-    return (
-        <Layout>
-            <h1 className="large-title">Nightly builds</h1>
-            <NavButton href="./releases" type="primary">Latest Release</NavButton>
-            <NavButton href="./archive" type="secondary">Release Archive</NavButton>
-            <ReleaseSelector
-                onVersionChange={(e: SyntheticEvent) => {
-                    console.log(e)
-                }}
-                onJVMChange={(e: SyntheticEvent) => {
-                    console.log(e)
-                }}
-            />
+  if (loading) {
+    return <Loading />;
+  }
 
-            <div>
-                <span>View</span>
-                <select id="numberpicker">
-                    <option value="10">10</option>
-                    <option value="20" selected={true}>20</option>
-                    <option value="50">50</option>
-                    <option value="100">100</option>
-                </select>
-                <span>builds prior to: </span>
-                <input type="text" id="datepicker"/>
-            </div>
+  return (
+    <Layout>
+      <h1 className="large-title">Nightly builds</h1>
+      <NavButton href="./releases" type="primary">
+        Latest Release
+      </NavButton>
+      <NavButton href="./archive" type="secondary">
+        Release Archive
+      </NavButton>
+      <ReleaseSelector
+        onVersionChange={(e: SyntheticEvent) => {
+          console.log(e);
+        }}
+        onJVMChange={(e: SyntheticEvent) => {
+          console.log(e);
+        }}
+      />
 
-            <input type="text" className="block margin-auto" id="search" placeholder="Search these builds"/>
+      <div>
+        <span>View</span>
+        <select id="numberpicker">
+          <option value="10">10</option>
+          <option value="20" selected={true}>
+            20
+          </option>
+          <option value="50">50</option>
+          <option value="100">100</option>
+        </select>
+        <span>builds prior to: </span>
+        <input type="text" id="datepicker" />
+      </div>
 
-            <h3 id="scroll-text" className="hide">Scroll horizontally <i className="fa fa-arrow-circle-o-right"
-                                                                         aria-hidden="true"/></h3>
-            <div id="search-error" className="hide">No search results</div>
+      <input
+        type="text"
+        className="block margin-auto"
+        id="search"
+        placeholder="Search these builds"
+      />
 
-            <div id="nightly-list">
-                <table id="table-parent">
-                    <thead id="table-head">
-                    <tr id='table-header'>
-                        <th>Platform</th>
-                        <th>Type</th>
-                        <th>Date</th>
-                        <th>Binary</th>
-                        <th>Installer</th>
-                        <th>Checksum</th>
-                    </tr>
-                    </thead>
-                    <tbody id="nightly-table">
-                    {platforms.map(() => {
-                        return (
-                            <tr className='nightly-container'>
-                                <td className='nightly-platform-block'>Linux aarch64</td>
-                                <td className='nightly-platform-type'>jdk</td>
-                                <td>
-                                    <div className='nightly-release-date'>13 June 2019</div>
-                                </td>
-                                <td className='nightly-downloads-block'>
-                                    <div>
-                                        <a className='dark-link' href="">
-                                            .tar.gz (99 MB)
-                                        </a>
-                                    </div>
-                                </td>
-                                {
-                                    thisInstallerLink ?
-                                        <td className='nightly-downloads-block'>
-                                            <div>
-                                                <a className='dark-link' href="">
-                                                    .pkg
-                                                </a>
-                                            </div>
-                                        </td>
-                                        :
-                                        <td className='nightly-downloads-block'>
-                                            <div>Not available</div>
-                                        </td>
-                                }
-                                <td><a href="" className='dark-link'>Checksum</a></td>
-                            </tr>
-                        )
-                    })
-                    }
-                    </tbody>
-                </table>
-            </div>
-        </Layout>
-    )
-}
+      <h3 id="scroll-text" className="hide">
+        Scroll horizontally{" "}
+        <i className="fa fa-arrow-circle-o-right" aria-hidden="true" />
+      </h3>
+      <div id="search-error" className="hide">
+        No search results
+      </div>
+
+      <div id="nightly-list">
+        <table id="table-parent">
+          <thead id="table-head">
+            <tr id="table-header">
+              <th>Platform</th>
+              <th>Type</th>
+              <th>Date</th>
+              <th>Binary</th>
+              <th>Installer</th>
+              <th>Checksum</th>
+            </tr>
+          </thead>
+          <tbody id="nightly-table">
+            {platforms.map(() => {
+              return (
+                <tr className="nightly-container">
+                  <td className="nightly-platform-block">Linux aarch64</td>
+                  <td className="nightly-platform-type">jdk</td>
+                  <td>
+                    <div className="nightly-release-date">13 June 2019</div>
+                  </td>
+                  <td className="nightly-downloads-block">
+                    <div>
+                      <a className="dark-link" href="">
+                        .tar.gz (99 MB)
+                      </a>
+                    </div>
+                  </td>
+                  {thisInstallerLink ? (
+                    <td className="nightly-downloads-block">
+                      <div>
+                        <a className="dark-link" href="">
+                          .pkg
+                        </a>
+                      </div>
+                    </td>
+                  ) : (
+                    <td className="nightly-downloads-block">
+                      <div>Not available</div>
+                    </td>
+                  )}
+                  <td>
+                    <a href="" className="dark-link">
+                      Checksum
+                    </a>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </Layout>
+  );
+};
 
 export default Nightly;

--- a/src/pages/releases.tsx
+++ b/src/pages/releases.tsx
@@ -1,64 +1,68 @@
-import React, {FunctionComponent, SyntheticEvent} from "react"
-import Layout from "../components/Layout"
-import Loading from "../components/Loading"
-import ReleasesPlatforms from "../components/Releases/ReleasesPlatforms"
-import ReleaseSelector from "../components/ReleaseSelector"
+import React, { FunctionComponent, SyntheticEvent } from "react";
+import Layout from "../components/Layout";
+import Loading from "../components/Loading";
+import ReleasesPlatforms from "../components/Releases/ReleasesPlatforms";
+import ReleaseSelector from "../components/ReleaseSelector";
 
-import "../scss/styles-4-releases.scss"
+import "../scss/styles-4-releases.scss";
 import NavButton from "../components/NavButton";
 
-export interface ReleasesProps {
-}
+export interface ReleasesProps {}
 
 export const Releases: FunctionComponent<ReleasesProps> = props => {
-
-    const loading = false
-    const platforms = [{
-        name: 'X64_LINUX',
-        logo: '',
-        official_name: 'Linux x64',
-        release_name: 'jdk8u212-b03',
-        release_link: '/',
-        release_datetime: '2019-04-18 03:49:04',
-        binaries: [
-            {
-                type: 'JDK',
-                link: 'https://www.github.com',
-                installer_link: '',
-                size: '99',
-                extension: '.tar.gz'
-            }
-        ]
-    }]
-
-    if (loading) {
-        <Loading/>
+  const loading = false;
+  const platforms = [
+    {
+      name: "X64_LINUX",
+      logo: "",
+      official_name: "Linux x64",
+      release_name: "jdk8u212-b03",
+      release_link: "/",
+      release_datetime: "2019-04-18 03:49:04",
+      binaries: [
+        {
+          type: "JDK",
+          link: "https://www.github.com",
+          installer_link: "",
+          size: "99",
+          extension: ".tar.gz"
+        }
+      ]
     }
+  ];
 
-    return (
-        <Layout>
-            <main className="grey-bg">
-                <div id="latest-page">
-                    <h1 className="large-title">Latest release</h1>
+  if (loading) {
+    <Loading />;
+  }
 
-                    <NavButton href="./archive" type="primary">Build archive</NavButton>
-                    <NavButton href="./nightly" type="secondary">Nightly builds</NavButton>
-                    <ReleaseSelector
-                        onVersionChange={(e: SyntheticEvent) => {
-                            console.log(e)
-                        }}
-                        onJVMChange={(e: SyntheticEvent) => {
-                            console.log(e)
-                        }}
-                    />
+  return (
+    <Layout>
+      <main className="grey-bg">
+        <div id="latest-page">
+          <h1 className="large-title">Latest release</h1>
 
-                    <div id="latest-container">
-                        <ReleasesPlatforms platforms={platforms}/>
-                    </div>
-                </div>
-            </main>
-        </Layout>
-    )
-}
+          <NavButton href="./archive" type="primary">
+            Build archive
+          </NavButton>
+          <NavButton href="./nightly" type="secondary">
+            Nightly builds
+          </NavButton>
+          <ReleaseSelector
+            onVersionChange={(e: SyntheticEvent) => {
+              console.log(e);
+            }}
+            onJVMChange={(e: SyntheticEvent) => {
+              console.log(e);
+            }}
+          />
 
-export default Releases
+          <div id="latest-container">
+            <ReleasesPlatforms platforms={platforms} />
+          </div>
+        </div>
+      </main>
+    </Layout>
+  );
+};
+
+export default Releases;

--- a/src/templates/markdownTemplate.js
+++ b/src/templates/markdownTemplate.js
@@ -1,29 +1,29 @@
-import React from "react"
-import { graphql } from "gatsby"
+import React from "react";
+import { graphql } from "gatsby";
 import Layout from "../components/Layout";
-import EditLink from '../components/EditLink';
+import EditLink from "../components/EditLink";
 
-import "../scss/styles-15-markdown.scss"
+import "../scss/styles-15-markdown.scss";
 
 export default function Template({
-  data, // this prop will be injected by the GraphQL query below.
+  data // this prop will be injected by the GraphQL query below.
 }) {
-  const { markdownRemark } = data // data.markdownRemark holds our post data
-  const { frontmatter, html } = markdownRemark
+  const { markdownRemark } = data; // data.markdownRemark holds our post data
+  const { frontmatter, html } = markdownRemark;
   return (
     <Layout>
-    <div className="markdown-container">
-      <div className="markdown">
-        <h1>{frontmatter.title}</h1>
-        <div
-          className="markdown-content"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
+      <div className="markdown-container">
+        <div className="markdown">
+          <h1>{frontmatter.title}</h1>
+          <div
+            className="markdown-content"
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+        </div>
       </div>
-    </div>
-    <EditLink relativePath={frontmatter.path} />
+      <EditLink relativePath={frontmatter.path} />
     </Layout>
-  )
+  );
 }
 
 export const pageQuery = graphql`
@@ -36,4 +36,4 @@ export const pageQuery = graphql`
       }
     }
   }
-`
+`;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,20 +1,19 @@
 declare module "*.png" {
-  const content: any
-  export default content
+  const content: any;
+  export default content;
 }
 
 declare module "*.svg" {
-  const content: any
-  export default content
+  const content: any;
+  export default content;
 }
 
 export interface Platform {
-  name?: string,
-  logo?: string,
-  official_name?: string
-  release_name?: string
-  release_link?: string
-  release_datetime?: string
-  binaries: object[]
+  name?: string;
+  logo?: string;
+  official_name?: string;
+  release_name?: string;
+  release_link?: string;
+  release_datetime?: string;
+  binaries: object[];
 }
-


### PR DESCRIPTION
Add a pre-commit script to run [Prettier](https://prettier.io/) on all changed files.

Run it on all existing files.

I'm not opinionated about formatting standards. If you are, please open a PR to update the `prettier` key in the package.json with some [Prettier options](https://prettier.io/docs/en/options.html) or let me know on this PR if you have a preference.

##### Checklist

- [X] `npm test` passes
- [X] documentation is changed or added (if applicable)
- [X] permission has been obtained to add new logo (if applicable)
- [X] contribution guidelines followed [here](https://github.com/AdoptOpenJDK/openjdk-website/blob/master/CONTRIBUTING.md)
